### PR TITLE
feat: update release configuration for tagging options

### DIFF
--- a/release-please-config.json
+++ b/release-please-config.json
@@ -3,6 +3,8 @@
     ".": {
       "changelog-path": "CHANGELOG.md",
       "release-type": "node",
+      "include-component-in-tag": false,
+      "include-v-in-tag": true,
       "bump-minor-pre-major": false,
       "bump-patch-for-minor-pre-major": false,
       "draft": false,


### PR DESCRIPTION
Configure release settings to include 'v' in the tag and exclude 
component name from the tag. This ensures a cleaner versioning 
strategy and aligns with standard tagging practices.