### PR TITLE
chore: update node versions in CI workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,7 +11,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        node-version: [ 14.x, 16.x, 18.x, 20.x ]
+        node-version: [ 18.x, 20.x, 22.x ]
 
     steps:
     - uses: actions/checkout@v2


### PR DESCRIPTION
Removes outdated node versions 14.x and 16.x from the CI 
workflow configuration and adds 22.x to support newer 
environments and features, ensuring compatibility with 
current dependencies.