### PR TITLE
ci: update GitHub Actions for release workflow

### DIFF
--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -26,11 +26,15 @@ jobs:
           token: ${{ steps.get_token.outputs.token }}
           config-file: release-please-config.json
           manifest-file: .release-please-manifest.json
-      - name: Setup Node.js
-        uses: actions/setup-node@f1f314fca9dfce2769ece7d933488f076716723e # v1
+      - uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5
+        with:
+          ref: ${{ steps.release.outputs.tag_name }}
+        if: ${{ steps.release.outputs.release_created }}
+      - name: Use Node.js ${{ matrix.node-version }}
+        uses: actions/setup-node@a0853c24544627f65ddf259abe73b1d18a591444 # v5
         with:
           node-version: 22
-          registry-url: https://registry.npmjs.org
+          cache: 'npm'
         if: ${{ steps.release.outputs.release_created }}
       - name: Install dependencies
         run: npm ci


### PR DESCRIPTION
Replace setup-node action and update checkout action to 
ensure proper versioning. Configure Node.js action to use 
caching for npm to improve build performance. Adjust 
checkout to use the correct reference for releases.