### PR TITLE
ci: add registry URL to release workflow for npm

### DIFF
--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -35,6 +35,7 @@ jobs:
         with:
           node-version: 22
           cache: 'npm'
+          registry-url: 'https://registry.npmjs.org'
         if: ${{ steps.release.outputs.release_created }}
       - name: Install dependencies
         run: npm ci


### PR DESCRIPTION
Add the `registry-url` configuration to the release workflow  
to specify the npm registry for package publishing. This  
ensures that the correct package registry is used during  
the release process.