### PR TITLE
fix: use exclusive transient queues for RabbitMQ 4.3+ compat

### DIFF
--- a/lib/index.test.ts
+++ b/lib/index.test.ts
@@ -469,7 +469,7 @@ describe("Connection", () => {
       {
         autoDelete: true,
         durable: false,
-        exclusive: false,
+        exclusive: true,
         expires: 432000000,
       }
     );

--- a/lib/index.ts
+++ b/lib/index.ts
@@ -222,7 +222,7 @@ class Connection {
     return this.channel!.assertQueue(queueName, {
       durable: false,
       autoDelete: true,
-      exclusive: false,
+      exclusive: true,
       expires: QUEUE_EXPIRATION,
     }).catch((e) => Promise.reject(new Error(e)));
   }


### PR DESCRIPTION
hey, ran into this when local broker hit 4.3, `transientEventStreamListener` consumers couldn't connect anymore.

## what's happening

`transientQueueDeclare` declares queues with `durable: false, autoDelete: true, exclusive: false`. RabbitMQ 4.3.0 deprecated that combo (`transient_nonexcl_queues`) and now rejects it by default:

> INTERNAL_ERROR - Feature `transient_nonexcl_queues` is deprecated.

so the connection just dies on startup.

## the fix

flip `exclusive: false` → `exclusive: true` in `transientQueueDeclare`. that's it, one line.

```diff
       durable: false,
       autoDelete: true,
-      exclusive: false,
+      exclusive: true,
       expires: QUEUE_EXPIRATION,
```

## why this is fine

- `exclusive: true` = queue tied to the declaring connection, dies when it closes. that's what a transient queue should be doing anyway
- fan-out still works since `transientEventStreamListener` already gives each consumer a unique queue name (`serviceEventRandomQueueName`), all bound to the same routing key. exclusive only restricts who consumes from a given queue, not the routing
- works on every broker version that supports AMQP 0-9-1 so 3.x and 4.0-4.2 keep working too

## tests

- had to flip the matching assertion on `lib/index.test.ts:472` (same `exclusive: false` → `exclusive: true`). all 32 pass, 100% coverage still
- also tested locally with 4 backend pods against rabbitmq 4.3.0, one published event lands in all 4 like before

## refs

- https://www.rabbitmq.com/docs/queues
- https://github.com/rabbitmq/rabbitmq-server/discussions/12972
